### PR TITLE
Fix inconsistent State after Autocheckout in Main Fragment

### DIFF
--- a/app/src/main/java/ch/ubique/notifyme/app/MainActivity.java
+++ b/app/src/main/java/ch/ubique/notifyme/app/MainActivity.java
@@ -111,9 +111,9 @@ public class MainActivity extends AppCompatActivity {
 	private void handleCustomIntents() {
 		String intentAction = getIntent().getAction();
 		if ((ACTION_REMINDER_NOTIFICATION.equals(intentAction) || ACTION_ONGOING_NOTIFICATION.equals(intentAction)) &&
-				viewModel.isCheckedIn()) {
+				viewModel.isCheckedIn().getValue()) {
 			showCheckedInScreen();
-		} else if (ACTION_CHECK_OUT_NOW.equals(intentAction) && viewModel.isCheckedIn()) {
+		} else if (ACTION_CHECK_OUT_NOW.equals(intentAction) && viewModel.isCheckedIn().getValue()) {
 			showCheckOutScreen();
 		} else if (ACTION_EXPOSURE_NOTIFICATION.equals(intentAction)) {
 			long id = getIntent().getLongExtra(EXPOSURE_ID_EXTRA, -1);
@@ -179,7 +179,7 @@ public class MainActivity extends AppCompatActivity {
 	private void checkValidCheckInIntent(String qrCodeData) {
 		try {
 			VenueInfo venueInfo = CrowdNotifier.getVenueInfo(qrCodeData, BuildConfig.ENTRY_QR_CODE_PREFIX);
-			if (viewModel.isCheckedIn()) {
+			if (viewModel.isCheckedIn().getValue()) {
 				new ErrorDialog(this, ErrorState.ALREADY_CHECKED_IN).show();
 			} else {
 				viewModel.setCheckInState(new CheckInState(false, venueInfo, System.currentTimeMillis(),

--- a/app/src/main/java/ch/ubique/notifyme/app/MainActivity.java
+++ b/app/src/main/java/ch/ubique/notifyme/app/MainActivity.java
@@ -73,7 +73,7 @@ public class MainActivity extends AppCompatActivity {
 		KeyLoadWorker.startKeyLoadWorker(this);
 		KeyLoadWorker.cleanUpOldData(this);
 
-		viewModel.forceUpdate.observe(this, forceUpdate -> {
+		viewModel.getForceUpdate().observe(this, forceUpdate -> {
 			if (forceUpdate) new ErrorDialog(this, ErrorState.FORCE_UPDATE_REQUIRED).show();
 		});
 	}

--- a/app/src/main/java/ch/ubique/notifyme/app/MainActivity.java
+++ b/app/src/main/java/ch/ubique/notifyme/app/MainActivity.java
@@ -34,6 +34,7 @@ import ch.ubique.notifyme.app.utils.Storage;
 
 import static ch.ubique.notifyme.app.utils.NotificationHelper.*;
 import static ch.ubique.notifyme.app.utils.ReminderHelper.ACTION_DID_AUTO_CHECKOUT;
+import static ch.ubique.notifyme.app.utils.ReminderHelper.autoCheckoutIfNecessary;
 
 public class MainActivity extends AppCompatActivity {
 
@@ -77,6 +78,7 @@ public class MainActivity extends AppCompatActivity {
 		});
 	}
 
+
 	@Override
 	protected void onNewIntent(Intent intent) {
 		super.onNewIntent(intent);
@@ -97,6 +99,7 @@ public class MainActivity extends AppCompatActivity {
 		super.onStart();
 		viewModel.refreshTraceKeys();
 		viewModel.refreshErrors();
+		autoCheckoutIfNecessary(this, viewModel.getCheckInState());
 	}
 
 	private void checkIntentForActions() {

--- a/app/src/main/java/ch/ubique/notifyme/app/MainFragment.java
+++ b/app/src/main/java/ch/ubique/notifyme/app/MainFragment.java
@@ -67,20 +67,23 @@ public class MainFragment extends Fragment implements MainActivity.BackPressList
 		reportsHeader.setOnClickListener(v -> showReportsFragment());
 		noReportsHeader.setOnClickListener(v -> showReportsFragment());
 
-		if (viewModel.isCheckedIn()) {
-			checkOutButton.setOnClickListener(v -> showCheckedInScreen());
-			checkInButton.setVisibility(View.GONE);
-			checkOutButton.setVisibility(View.VISIBLE);
-			checkedInLabel.setVisibility(View.VISIBLE);
-			viewModel.timeSinceCheckIn.observe(getViewLifecycleOwner(),
-					duration -> checkOutButton.setText(StringUtils.getShortDurationString(duration)));
-			viewModel.startCheckInTimer();
-		} else {
-			checkInButton.setOnClickListener(v -> showQRCodeScanner());
-			checkInButton.setVisibility(View.VISIBLE);
-			checkOutButton.setVisibility(View.GONE);
-			checkedInLabel.setVisibility(View.GONE);
-		}
+		viewModel.isCheckedIn().observe(getViewLifecycleOwner(), isCheckedIn -> {
+			if (isCheckedIn) {
+				checkOutButton.setOnClickListener(v -> showCheckedInScreen());
+				checkInButton.setVisibility(View.GONE);
+				checkOutButton.setVisibility(View.VISIBLE);
+				checkedInLabel.setVisibility(View.VISIBLE);
+				viewModel.startCheckInTimer();
+			} else {
+				checkInButton.setOnClickListener(v -> showQRCodeScanner());
+				checkInButton.setVisibility(View.VISIBLE);
+				checkOutButton.setVisibility(View.GONE);
+				checkedInLabel.setVisibility(View.GONE);
+			}
+		});
+
+		viewModel.timeSinceCheckIn.observe(getViewLifecycleOwner(),
+				duration -> checkOutButton.setText(StringUtils.getShortDurationString(duration)));
 
 		viewModel.exposures.observe(getViewLifecycleOwner(), reports -> {
 			if (reports == null || reports.isEmpty()) {

--- a/app/src/main/java/ch/ubique/notifyme/app/MainFragment.java
+++ b/app/src/main/java/ch/ubique/notifyme/app/MainFragment.java
@@ -82,10 +82,10 @@ public class MainFragment extends Fragment implements MainActivity.BackPressList
 			}
 		});
 
-		viewModel.timeSinceCheckIn.observe(getViewLifecycleOwner(),
+		viewModel.getTimeSinceCheckIn().observe(getViewLifecycleOwner(),
 				duration -> checkOutButton.setText(StringUtils.getShortDurationString(duration)));
 
-		viewModel.exposures.observe(getViewLifecycleOwner(), reports -> {
+		viewModel.getExposures().observe(getViewLifecycleOwner(), reports -> {
 			if (reports == null || reports.isEmpty()) {
 				noReportsHeader.setVisibility(View.VISIBLE);
 				reportsHeader.setVisibility(View.GONE);
@@ -115,9 +115,9 @@ public class MainFragment extends Fragment implements MainActivity.BackPressList
 			}
 		});
 
-		viewModel.errorState.observe(getViewLifecycleOwner(), errorState -> {
+		viewModel.getErrorState().observe(getViewLifecycleOwner(), errorState -> {
 			if (errorState == null) {
-				List<ExposureEvent> reports = viewModel.exposures.getValue();
+				List<ExposureEvent> reports = viewModel.getExposures().getValue();
 				if (reports == null || reports.isEmpty()) {
 					splashText.setVisibility(View.VISIBLE);
 					mainImageView.setVisibility(View.VISIBLE);
@@ -141,7 +141,7 @@ public class MainFragment extends Fragment implements MainActivity.BackPressList
 
 		swipeRefreshLayout.setOnRefreshListener(() -> viewModel.refreshTraceKeys());
 
-		viewModel.traceKeyLoadingState.observe(getViewLifecycleOwner(), loadingState ->
+		viewModel.getTraceKeyLoadingState().observe(getViewLifecycleOwner(), loadingState ->
 				swipeRefreshLayout.setRefreshing(loadingState == MainViewModel.LoadingState.LOADING));
 
 		if (BuildConfig.FLAVOR.equals("prod")) {

--- a/app/src/main/java/ch/ubique/notifyme/app/MainViewModel.java
+++ b/app/src/main/java/ch/ubique/notifyme/app/MainViewModel.java
@@ -10,6 +10,7 @@ import android.os.Looper;
 import androidx.annotation.NonNull;
 import androidx.core.app.NotificationManagerCompat;
 import androidx.lifecycle.AndroidViewModel;
+import androidx.lifecycle.LiveData;
 import androidx.lifecycle.MutableLiveData;
 import androidx.localbroadcastmanager.content.LocalBroadcastManager;
 
@@ -37,6 +38,7 @@ public class MainViewModel extends AndroidViewModel {
 	public MutableLiveData<LoadingState> traceKeyLoadingState = new MutableLiveData<>(LoadingState.SUCCESS);
 	public MutableLiveData<ErrorState> errorState = new MutableLiveData<>(null);
 	public MutableLiveData<Boolean> forceUpdate = new MutableLiveData<>(false);
+	private MutableLiveData<Boolean> isCheckedIn = new MutableLiveData<>(false);
 	private CheckInState checkInState;
 
 	private Storage storage;
@@ -88,6 +90,11 @@ public class MainViewModel extends AndroidViewModel {
 	public void setCheckInState(CheckInState checkInState) {
 		storage.setCurrentVenue(checkInState);
 		this.checkInState = checkInState;
+		if (checkInState == null) {
+			this.isCheckedIn.setValue(false);
+		} else {
+			this.isCheckedIn.setValue(checkInState.isCheckedIn());
+		}
 	}
 
 	public CheckInState getCheckInState() {
@@ -96,15 +103,11 @@ public class MainViewModel extends AndroidViewModel {
 
 	public void setCheckedIn(boolean checkedIn) {
 		if (checkInState != null) checkInState.setCheckedIn(checkedIn);
-		storage.setCurrentVenue(checkInState);
+		setCheckInState(checkInState);
 	}
 
-	public boolean isCheckedIn() {
-		if (checkInState == null) {
-			return false;
-		} else {
-			return checkInState.isCheckedIn();
-		}
+	public LiveData<Boolean> isCheckedIn() {
+		return isCheckedIn;
 	}
 
 	public void refreshTraceKeys() {

--- a/app/src/main/java/ch/ubique/notifyme/app/MainViewModel.java
+++ b/app/src/main/java/ch/ubique/notifyme/app/MainViewModel.java
@@ -33,12 +33,12 @@ import static ch.ubique.notifyme.app.utils.ReminderHelper.ACTION_DID_AUTO_CHECKO
 public class MainViewModel extends AndroidViewModel {
 
 
-	public MutableLiveData<List<ExposureEvent>> exposures = new MutableLiveData<>();
-	public MutableLiveData<Long> timeSinceCheckIn = new MutableLiveData<>(0L);
-	public MutableLiveData<LoadingState> traceKeyLoadingState = new MutableLiveData<>(LoadingState.SUCCESS);
-	public MutableLiveData<ErrorState> errorState = new MutableLiveData<>(null);
-	public MutableLiveData<Boolean> forceUpdate = new MutableLiveData<>(false);
-	private MutableLiveData<Boolean> isCheckedIn = new MutableLiveData<>(false);
+	private final MutableLiveData<List<ExposureEvent>> exposures = new MutableLiveData<>();
+	private final MutableLiveData<Long> timeSinceCheckIn = new MutableLiveData<>(0L);
+	private final MutableLiveData<LoadingState> traceKeyLoadingState = new MutableLiveData<>(LoadingState.SUCCESS);
+	private final MutableLiveData<ErrorState> errorState = new MutableLiveData<>(null);
+	private final MutableLiveData<Boolean> forceUpdate = new MutableLiveData<>(false);
+	private final MutableLiveData<Boolean> isCheckedIn = new MutableLiveData<>(false);
 	private CheckInState checkInState;
 
 	private Storage storage;
@@ -104,6 +104,26 @@ public class MainViewModel extends AndroidViewModel {
 	public void setCheckedIn(boolean checkedIn) {
 		if (checkInState != null) checkInState.setCheckedIn(checkedIn);
 		setCheckInState(checkInState);
+	}
+
+	public LiveData<List<ExposureEvent>> getExposures() {
+		return exposures;
+	}
+
+	public LiveData<Long> getTimeSinceCheckIn() {
+		return timeSinceCheckIn;
+	}
+
+	public LiveData<LoadingState> getTraceKeyLoadingState() {
+		return traceKeyLoadingState;
+	}
+
+	public LiveData<ErrorState> getErrorState() {
+		return errorState;
+	}
+
+	public LiveData<Boolean> getForceUpdate() {
+		return forceUpdate;
 	}
 
 	public LiveData<Boolean> isCheckedIn() {

--- a/app/src/main/java/ch/ubique/notifyme/app/MainViewModel.java
+++ b/app/src/main/java/ch/ubique/notifyme/app/MainViewModel.java
@@ -63,7 +63,7 @@ public class MainViewModel extends AndroidViewModel {
 		super(application);
 		refreshExposures();
 		storage = Storage.getInstance(getApplication());
-		checkInState = storage.getCurrentVenue();
+		checkInState = storage.getCheckInState();
 		LocalBroadcastManager localBroadcastManager = LocalBroadcastManager.getInstance(application);
 		localBroadcastManager.registerReceiver(broadcastReceiver, new IntentFilter(ACTION_DID_AUTO_CHECKOUT));
 		localBroadcastManager.registerReceiver(broadcastReceiver, new IntentFilter(ACTION_NEW_EXPOSURE_NOTIFICATION));
@@ -88,7 +88,7 @@ public class MainViewModel extends AndroidViewModel {
 	}
 
 	public void setCheckInState(CheckInState checkInState) {
-		storage.setCurrentVenue(checkInState);
+		storage.setCheckInState(checkInState);
 		this.checkInState = checkInState;
 		if (checkInState == null) {
 			this.isCheckedIn.setValue(false);
@@ -164,7 +164,7 @@ public class MainViewModel extends AndroidViewModel {
 
 	public void setSelectedReminderOption(ReminderOption selectedReminderOption) {
 		this.checkInState.setSelectedTimerOption(selectedReminderOption);
-		storage.setCurrentVenue(checkInState);
+		storage.setCheckInState(checkInState);
 	}
 
 	public void reloadConfig() {

--- a/app/src/main/java/ch/ubique/notifyme/app/checkin/CheckedInFragment.java
+++ b/app/src/main/java/ch/ubique/notifyme/app/checkin/CheckedInFragment.java
@@ -69,7 +69,7 @@ public class CheckedInFragment extends Fragment implements MainActivity.BackPres
 		toolbar.setNavigationOnClickListener(v -> onBackPressed());
 
 		viewModel.startCheckInTimer();
-		viewModel.timeSinceCheckIn
+		viewModel.getTimeSinceCheckIn()
 				.observe(getViewLifecycleOwner(), duration -> timerTextView.setText(StringUtils.getDurationString(duration)));
 
 		titleTextView.setText(venueInfo.getTitle());

--- a/app/src/main/java/ch/ubique/notifyme/app/diary/DiaryFragment.java
+++ b/app/src/main/java/ch/ubique/notifyme/app/diary/DiaryFragment.java
@@ -58,7 +58,7 @@ public class DiaryFragment extends Fragment {
 		recyclerView.setAdapter(recyclerAdapter);
 		recyclerView.setLayoutManager(new LinearLayoutManager(getContext()));
 
-		viewModel.exposures.observe(getViewLifecycleOwner(), exposures -> {
+		viewModel.getExposures().observe(getViewLifecycleOwner(), exposures -> {
 			ArrayList<VenueVisitRecyclerItem> items = new ArrayList<>();
 
 			List<DiaryEntry> diaryEntries = DiaryStorage.getInstance(getContext()).getEntries();

--- a/app/src/main/java/ch/ubique/notifyme/app/network/KeyLoadWorker.java
+++ b/app/src/main/java/ch/ubique/notifyme/app/network/KeyLoadWorker.java
@@ -17,6 +17,9 @@ import org.crowdnotifier.android.sdk.model.ProblematicEventInfo;
 import ch.ubique.notifyme.app.BuildConfig;
 import ch.ubique.notifyme.app.utils.DiaryStorage;
 import ch.ubique.notifyme.app.utils.NotificationHelper;
+import ch.ubique.notifyme.app.utils.Storage;
+
+import static ch.ubique.notifyme.app.utils.ReminderHelper.autoCheckoutIfNecessary;
 
 public class KeyLoadWorker extends Worker {
 
@@ -63,6 +66,7 @@ public class KeyLoadWorker extends Worker {
 			LocalBroadcastManager.getInstance(getApplicationContext()).sendBroadcast(new Intent(ACTION_NEW_EXPOSURE_NOTIFICATION));
 		}
 		cleanUpOldData(getApplicationContext());
+		autoCheckoutIfNecessary(getApplicationContext(), Storage.getInstance(getApplicationContext()).getCheckInState());
 
 		Log.d(LOG_TAG, "KeyLoadWorker success");
 		return Result.success();

--- a/app/src/main/java/ch/ubique/notifyme/app/qr/QrCodeScannerFragment.java
+++ b/app/src/main/java/ch/ubique/notifyme/app/qr/QrCodeScannerFragment.java
@@ -185,8 +185,9 @@ public class QrCodeScannerFragment extends Fragment implements QrCodeAnalyzer.Li
 		try {
 			VenueInfo venueInfo = CrowdNotifier.getVenueInfo(qrCodeData, BuildConfig.ENTRY_QR_CODE_PREFIX);
 			isQRScanningEnabled = false;
-			viewModel.setCheckInState(new CheckInState(false, venueInfo, System.currentTimeMillis(), System.currentTimeMillis(),
-					ReminderOption.OFF));
+			if (getActivity() != null) getActivity().runOnUiThread(() -> viewModel.setCheckInState(
+					new CheckInState(false, venueInfo, System.currentTimeMillis(), System.currentTimeMillis(),
+							ReminderOption.OFF)));
 			showCheckInFragment();
 		} catch (QrUtils.QRException e) {
 			handleInvalidQRCodeExceptions(qrCodeData, e);

--- a/app/src/main/java/ch/ubique/notifyme/app/reports/ReportsFragment.java
+++ b/app/src/main/java/ch/ubique/notifyme/app/reports/ReportsFragment.java
@@ -57,14 +57,14 @@ public class ReportsFragment extends Fragment {
 		recyclerView.setLayoutManager(new LinearLayoutManager(getContext()));
 
 		diaryStorage = DiaryStorage.getInstance(getContext());
-		viewModel.exposures
-				.observe(getViewLifecycleOwner(), exposures -> publishRecyclerItems(exposures, viewModel.errorState.getValue()));
-		viewModel.errorState
-				.observe(getViewLifecycleOwner(), errorState -> publishRecyclerItems(viewModel.exposures.getValue(), errorState));
+		viewModel.getExposures()
+				.observe(getViewLifecycleOwner(), exposures -> publishRecyclerItems(exposures, viewModel.getErrorState().getValue()));
+		viewModel.getErrorState()
+				.observe(getViewLifecycleOwner(), errorState -> publishRecyclerItems(viewModel.getExposures().getValue(), errorState));
 
 		swipeRefreshLayout.setOnRefreshListener(() -> viewModel.refreshTraceKeys());
 
-		viewModel.traceKeyLoadingState.observe(getViewLifecycleOwner(), loadingState ->
+		viewModel.getTraceKeyLoadingState().observe(getViewLifecycleOwner(), loadingState ->
 				swipeRefreshLayout.setRefreshing(loadingState == MainViewModel.LoadingState.LOADING));
 	}
 

--- a/app/src/main/java/ch/ubique/notifyme/app/utils/ReminderHelper.java
+++ b/app/src/main/java/ch/ubique/notifyme/app/utils/ReminderHelper.java
@@ -24,7 +24,7 @@ public class ReminderHelper extends BroadcastReceiver {
 	private static final int AUTO_CHECK_OUT_INTENT_ID = 14;
 	private static final String ACTION_AUTO_CHECKOUT = BuildConfig.APPLICATION_ID + ".ACTION_AUTO_CHECKOUT";
 	private static final long EIGHT_HOURS = 1000L * 60 * 60 * 8;
-	private static final long TWELVE_HOURS = 1000L * 60 * 60 * 12;
+	public static final long TWELVE_HOURS = 1000L * 60 * 60 * 12;
 
 	public static void removeAllReminders(Context context) {
 		removeReminder(context);
@@ -95,27 +95,29 @@ public class ReminderHelper extends BroadcastReceiver {
 
 	@Override
 	public void onReceive(Context context, Intent intent) {
-		CheckInState checkInState = Storage.getInstance(context).getCurrentVenue();
+		CheckInState checkInState = Storage.getInstance(context).getCheckInState();
 		if (ACTION_REMINDER.equals(intent.getAction()) ||
 				ACTION_EIGHT_HOUR_REMINDER.equals(intent.getAction()) && checkInState != null) {
 			NotificationHelper.getInstance(context).showReminderNotification();
-		} else if (ACTION_AUTO_CHECKOUT.equals(intent.getAction()) && checkInState != null) {
-			autoCheckout(context, checkInState);
+		} else if (ACTION_AUTO_CHECKOUT.equals(intent.getAction())) {
+			autoCheckoutIfNecessary(context, checkInState);
 		}
 	}
 
-	private void autoCheckout(Context context, CheckInState checkInState) {
-		NotificationHelper notificationHelper = NotificationHelper.getInstance(context);
-		notificationHelper.stopOngoingNotification();
-		notificationHelper.removeReminderNotification();
-		notificationHelper.showAutoCheckoutNotification();
-		long checkIn = checkInState.getCheckInTime();
-		long checkOut = checkIn + TWELVE_HOURS;
-		long id = CrowdNotifier.addCheckIn(checkIn, checkOut, checkInState.getVenueInfo(), context);
-		DiaryStorage.getInstance(context).addEntry(new DiaryEntry(id, checkIn, checkOut, checkInState.getVenueInfo(), ""));
-		Storage storage = Storage.getInstance(context);
-		storage.setCurrentVenue(null);
-		LocalBroadcastManager.getInstance(context).sendBroadcast(new Intent(ACTION_DID_AUTO_CHECKOUT));
+	public static void autoCheckoutIfNecessary(Context context, CheckInState checkInState) {
+		if (checkInState != null && checkInState.getCheckInTime() <= System.currentTimeMillis() - TWELVE_HOURS) {
+			NotificationHelper notificationHelper = NotificationHelper.getInstance(context);
+			notificationHelper.stopOngoingNotification();
+			notificationHelper.removeReminderNotification();
+			notificationHelper.showAutoCheckoutNotification();
+			long checkIn = checkInState.getCheckInTime();
+			long checkOut = checkIn + TWELVE_HOURS;
+			long id = CrowdNotifier.addCheckIn(checkIn, checkOut, checkInState.getVenueInfo(), context);
+			DiaryStorage.getInstance(context).addEntry(new DiaryEntry(id, checkIn, checkOut, checkInState.getVenueInfo(), ""));
+			Storage storage = Storage.getInstance(context);
+			storage.setCheckInState(null);
+			LocalBroadcastManager.getInstance(context).sendBroadcast(new Intent(ACTION_DID_AUTO_CHECKOUT));
+		}
 	}
 
 }

--- a/app/src/main/java/ch/ubique/notifyme/app/utils/Storage.java
+++ b/app/src/main/java/ch/ubique/notifyme/app/utils/Storage.java
@@ -30,11 +30,11 @@ public class Storage {
 		return instance;
 	}
 
-	public void setCurrentVenue(CheckInState checkInState) {
+	public void setCheckInState(CheckInState checkInState) {
 		sharedPreferences.edit().putString(KEY_CURRENT_CHECK_IN, gson.toJson(checkInState)).apply();
 	}
 
-	public CheckInState getCurrentVenue() {
+	public CheckInState getCheckInState() {
 		return gson.fromJson(sharedPreferences.getString(KEY_CURRENT_CHECK_IN, null), CheckInState.class);
 	}
 


### PR DESCRIPTION
This PR includes two Fixes:

1. A bug is fixed which allowed the app to enter an inconsistent state after an Auto-Checkout happened
2. If the user opens the App and there is an active Check-In that is ongoing for more than 12 hours, the user is automatically checked out. (Additionally this check is also performed in the KeyLoadWorker)